### PR TITLE
Acceptance tests clean up

### DIFF
--- a/test/WebApiBook.IssueTrackerApi.AcceptanceTests/Features/CreatingIssues.cs
+++ b/test/WebApiBook.IssueTrackerApi.AcceptanceTests/Features/CreatingIssues.cs
@@ -13,36 +13,36 @@ namespace WebApiBook.IssueTrackerApp.AcceptanceTests.Features
 {
     public class CreatingIssues : IssuesFeature
     {
-        private Uri _issues = new Uri("http://localhost/issue");
+        private readonly Uri _issues = new Uri("http://localhost/issue");
 
         [Scenario]
         public void CreatingANewIssue(dynamic newIssue)
         {
             "Given a new issue".
                 f(() =>
-                    {
-                        newIssue = new JObject();
-                        newIssue.description = "A new issue";
-                        newIssue.title = "NewIssue";
-                        MockIssueStore.Setup(i => i.CreateAsync(It.IsAny<Issue>())).Returns<Issue>( issue=>
-                            {
-                                issue.Id = "1";
-                                return Task.FromResult("");
-                            });
-                    });
+                {
+                    newIssue = new JObject();
+                    newIssue.description = "A new issue";
+                    newIssue.title = "NewIssue";
+                    MockIssueStore.Setup(i => i.CreateAsync(It.IsAny<Issue>())).Returns<Issue>( issue=>
+                        {
+                            issue.Id = "1";
+                            return Task.FromResult("");
+                        });
+                });
             "When a POST request is made".
                 f(() =>
-                    {
-                        Request.Method = HttpMethod.Post;
-                        Request.RequestUri = _issues;
-                        Request.Content = new ObjectContent<dynamic>(newIssue, new JsonMediaTypeFormatter());
-                        Response = Client.SendAsync(Request).Result;
-                    });
+                {
+                    Request.Method = HttpMethod.Post;
+                    Request.RequestUri = _issues;
+                    Request.Content = new ObjectContent<dynamic>(newIssue, new JsonMediaTypeFormatter());
+                    Response = Client.SendAsync(Request).Result;
+                });
             "Then the issue should be added".
                 f(() => MockIssueStore.Verify(i => i.CreateAsync(It.IsAny<Issue>())));
-            "Then a '201 Created' status is returned".
+            "And a '201 Created' status is returned".
                 f(() => Response.StatusCode.ShouldEqual(HttpStatusCode.Created));
-            "Then the response location header will be set to the resource location".
+            "And the response location header will be set to the resource location".
                 f(() => Response.Headers.Location.AbsoluteUri.ShouldEqual("http://localhost/issue/1"));
         }
     }

--- a/test/WebApiBook.IssueTrackerApi.AcceptanceTests/Features/DeletingIssues.cs
+++ b/test/WebApiBook.IssueTrackerApi.AcceptanceTests/Features/DeletingIssues.cs
@@ -11,28 +11,28 @@ namespace WebApiBook.IssueTrackerApp.AcceptanceTests.Features
 {
     public class DeletingIssues : IssuesFeature
     {
-        private Uri _uriIssue = new Uri("http://localhost/issue/1");
+        private readonly Uri _uriIssue = new Uri("http://localhost/issue/1");
 
         [Scenario]
         public void DeletingAnIssue(Issue fakeIssue)
         {
             "Given an existing issue".
                 f(() =>
-                    {
-                        fakeIssue = FakeIssues.FirstOrDefault();
-                        MockIssueStore.Setup(i => i.FindAsync("1")).Returns(Task.FromResult(fakeIssue));
-                        MockIssueStore.Setup(i => i.DeleteAsync("1")).Returns(Task.FromResult(""));
-                    });
+                {
+                    fakeIssue = FakeIssues.FirstOrDefault();
+                    MockIssueStore.Setup(i => i.FindAsync("1")).Returns(Task.FromResult(fakeIssue));
+                    MockIssueStore.Setup(i => i.DeleteAsync("1")).Returns(Task.FromResult(""));
+                });
             "When a DELETE request is made".
                 f(() =>
-                    {
-                        Request.RequestUri = _uriIssue;
-                        Request.Method = HttpMethod.Delete;
-                        Response = Client.SendAsync(Request).Result;
-                    });
+                {
+                    Request.RequestUri = _uriIssue;
+                    Request.Method = HttpMethod.Delete;
+                    Response = Client.SendAsync(Request).Result;
+                });
             "Then the issue should be removed".
                 f(() => MockIssueStore.Verify(i => i.DeleteAsync("1")));
-            "Then a '200 OK status' is returned".
+            "And a '200 OK status' is returned".
                 f(() => Response.StatusCode.ShouldEqual(HttpStatusCode.OK));
         }
 
@@ -43,11 +43,11 @@ namespace WebApiBook.IssueTrackerApp.AcceptanceTests.Features
                 f(() => MockIssueStore.Setup(i => i.FindAsync("1")).Returns(Task.FromResult((Issue) null)));
             "When a DELETE request is made".
                 f(() =>
-                    {
-                        Request.RequestUri = _uriIssue;
-                        Request.Method = HttpMethod.Delete;
-                        Response = Client.SendAsync(Request).Result;
-                    });
+                {
+                    Request.RequestUri = _uriIssue;
+                    Request.Method = HttpMethod.Delete;
+                    Response = Client.SendAsync(Request).Result;
+                });
             "Then a '404 Not Found' status is returned".
                 f(() => Response.StatusCode.ShouldEqual(HttpStatusCode.NotFound));
         }

--- a/test/WebApiBook.IssueTrackerApi.AcceptanceTests/Features/ProcessingIssues.cs
+++ b/test/WebApiBook.IssueTrackerApi.AcceptanceTests/Features/ProcessingIssues.cs
@@ -3,8 +3,6 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
-using Moq;
-using Newtonsoft.Json.Linq;
 using Should;
 using WebApiBook.IssueTrackerApi.Models;
 using Xbehave;
@@ -13,33 +11,33 @@ namespace WebApiBook.IssueTrackerApp.AcceptanceTests.Features
 {
     public class ProcessingIssues : IssuesFeature
     {
-        private string _uriProcessor = "http://localhost/issueprocessor/1?";
+        private readonly string _uriProcessor = "http://localhost/issueprocessor/1?";
 
         [Scenario]
         public void ClosingAnOpenIssue(Issue issue)
         {
             "Given an existing open issue".
                 f(() =>
-                    {
-                        issue = FakeIssues.FirstOrDefault(i => i.Status == IssueStatus.Open);
-                        MockIssueStore.Setup(i => i.FindAsync("1")).Returns(Task.FromResult(issue));
-                        MockIssueStore.Setup(i => i.UpdateAsync(issue)).Returns(Task.FromResult(""));
-                    });
+                {
+                    issue = FakeIssues.FirstOrDefault(i => i.Status == IssueStatus.Open);
+                    MockIssueStore.Setup(i => i.FindAsync("1")).Returns(Task.FromResult(issue));
+                    MockIssueStore.Setup(i => i.UpdateAsync(issue)).Returns(Task.FromResult(""));
+                });
             "When a POST request is made to the issue processor AND the action is 'close'".
                 f(() =>
-                    {
-                        Request.RequestUri = new Uri(_uriProcessor + "action=close");
-                        Request.Method = HttpMethod.Post;
-                        Response = Client.SendAsync(Request).Result;
-                    });
+                {
+                    Request.RequestUri = new Uri(_uriProcessor + "action=close");
+                    Request.Method = HttpMethod.Post;
+                    Response = Client.SendAsync(Request).Result;
+                });
             "Then a '200 OK' status is returned".
                 f(() => Response.StatusCode.ShouldEqual(HttpStatusCode.OK));
-            "Then the issue is closed".
+            "And the issue is closed".
                 f(() =>
-                    {
-                        issue.Status.ShouldEqual(IssueStatus.Closed);
-                        MockIssueStore.Verify(i => i.UpdateAsync(issue));
-                    });
+                {
+                    issue.Status.ShouldEqual(IssueStatus.Closed);
+                    MockIssueStore.Verify(i => i.UpdateAsync(issue));
+                });
         }
 
         [Scenario]
@@ -54,14 +52,14 @@ namespace WebApiBook.IssueTrackerApp.AcceptanceTests.Features
                 });
             "When a POST request is made to the issue processor AND the action is 'transition'".
                 f(() =>
-                    {
-                        Request.RequestUri = new Uri(_uriProcessor + "action=transition");
-                        Request.Method = HttpMethod.Post;
-                        Response = Client.SendAsync(Request).Result;
-                    });
+                {
+                    Request.RequestUri = new Uri(_uriProcessor + "action=transition");
+                    Request.Method = HttpMethod.Post;
+                    Response = Client.SendAsync(Request).Result;
+                });
             "Then a '200 OK' status is returned".
                 f(() => Response.StatusCode.ShouldEqual(HttpStatusCode.OK));
-            "Then the issue is closed".
+            "And the issue is closed".
                 f(() =>
                 {
                     issue.Status.ShouldEqual(IssueStatus.Closed);
@@ -81,11 +79,11 @@ namespace WebApiBook.IssueTrackerApp.AcceptanceTests.Features
                 });
             "When a POST request is made to the issue processor AND the action is 'close'".
                 f(() =>
-                    {
-                        Request.RequestUri = new Uri(_uriProcessor + "action=close");
-                        Request.Method = HttpMethod.Post;
-                        Response = Client.SendAsync(Request).Result;
-                    });
+                {
+                    Request.RequestUri = new Uri(_uriProcessor + "action=close");
+                    Request.Method = HttpMethod.Post;
+                    Response = Client.SendAsync(Request).Result;
+                });
             "Then a '200 OK' status is returned".
                 f(() => Response.StatusCode.ShouldEqual(HttpStatusCode.BadRequest));
         }
@@ -93,8 +91,8 @@ namespace WebApiBook.IssueTrackerApp.AcceptanceTests.Features
         [Scenario]
         public void OpeningAClosedIssue(Issue issue)
         {
-           "Given an existing closed issue".
-                f(() =>
+            "Given an existing closed issue".
+                 f(() =>
                 {
                     issue = FakeIssues.FirstOrDefault(i => i.Status == IssueStatus.Closed);
                     MockIssueStore.Setup(i => i.FindAsync("1")).Returns(Task.FromResult(issue));
@@ -102,14 +100,14 @@ namespace WebApiBook.IssueTrackerApp.AcceptanceTests.Features
                 });
             "When a POST request is made to the issue processor AND the action is 'open'".
                 f(() =>
-                    {
-                        Request.RequestUri = new Uri(_uriProcessor + "action=open");
-                        Request.Method = HttpMethod.Post;
-                        Response = Client.SendAsync(Request).Result;
-                    });
+                {
+                    Request.RequestUri = new Uri(_uriProcessor + "action=open");
+                    Request.Method = HttpMethod.Post;
+                    Response = Client.SendAsync(Request).Result;
+                });
             "Then a '200 OK' status is returned".
                 f(() => Response.StatusCode.ShouldEqual(HttpStatusCode.OK));
-            "Then the issue is closed".
+            "And the issue is closed".
                 f(() =>
                 {
                     issue.Status.ShouldEqual(IssueStatus.Open);
@@ -129,14 +127,14 @@ namespace WebApiBook.IssueTrackerApp.AcceptanceTests.Features
                 });
             "When a POST request is made to the issue processor AND the action is 'open'".
                 f(() =>
-                    {
-                        Request.RequestUri = new Uri(_uriProcessor + "action=open");
-                        Request.Method = HttpMethod.Post;
-                        Response = Client.SendAsync(Request).Result;
-                    });
+                {
+                    Request.RequestUri = new Uri(_uriProcessor + "action=open");
+                    Request.Method = HttpMethod.Post;
+                    Response = Client.SendAsync(Request).Result;
+                });
             "Then a '200 OK' status is returned".
                 f(() => Response.StatusCode.ShouldEqual(HttpStatusCode.OK));
-            "Then the issue is closed".
+            "And the issue is closed".
                 f(() =>
                 {
                     issue.Status.ShouldEqual(IssueStatus.Open);
@@ -156,11 +154,11 @@ namespace WebApiBook.IssueTrackerApp.AcceptanceTests.Features
                 });
             "When a POST request is made to the issue processor AND the action is 'open'".
                 f(() =>
-                    {
-                        Request.RequestUri = new Uri(_uriProcessor + "action=close");
-                        Request.Method = HttpMethod.Post;
-                        Response = Client.SendAsync(Request).Result;
-                    });
+                {
+                    Request.RequestUri = new Uri(_uriProcessor + "action=close");
+                    Request.Method = HttpMethod.Post;
+                    Response = Client.SendAsync(Request).Result;
+                });
             "Then a '400 Bad Request' status is returned".
                 f(() => Response.StatusCode.ShouldEqual(HttpStatusCode.BadRequest));
         }
@@ -172,11 +170,11 @@ namespace WebApiBook.IssueTrackerApp.AcceptanceTests.Features
                 f(() => MockIssueStore.Setup(i => i.FindAsync("1")).Returns(Task.FromResult((Issue)null)));
             "When a POST request is made to the issue processor AND the action is 'open'".
                 f(() =>
-                    {
-                        Request.RequestUri = new Uri(_uriProcessor + "action=open");
-                        Request.Method = HttpMethod.Post;
-                        Response = Client.SendAsync(Request).Result;
-                    });
+                {
+                    Request.RequestUri = new Uri(_uriProcessor + "action=open");
+                    Request.Method = HttpMethod.Post;
+                    Response = Client.SendAsync(Request).Result;
+                });
             "Then a '404 Not Found' status is returned".
                 f(() => Response.StatusCode.ShouldEqual(HttpStatusCode.NotFound));
         }
@@ -188,11 +186,11 @@ namespace WebApiBook.IssueTrackerApp.AcceptanceTests.Features
                 f(() => MockIssueStore.Setup(i => i.FindAsync("1")).Returns(Task.FromResult((Issue)null)));
             "When a POST request is made to the issue processor AND the action is 'close'".
                 f(() =>
-                    {
-                        Request.RequestUri = new Uri(_uriProcessor + "action=close");
-                        Request.Method = HttpMethod.Post;
-                        Response = Client.SendAsync(Request).Result;
-                    });
+                {
+                    Request.RequestUri = new Uri(_uriProcessor + "action=close");
+                    Request.Method = HttpMethod.Post;
+                    Response = Client.SendAsync(Request).Result;
+                });
             "Then a '404 Not Found' status is returned".
                 f(() => Response.StatusCode.ShouldEqual(HttpStatusCode.NotFound));
         }
@@ -204,15 +202,13 @@ namespace WebApiBook.IssueTrackerApp.AcceptanceTests.Features
                 f(() => MockIssueStore.Setup(i => i.FindAsync("1")).Returns(Task.FromResult((Issue)null)));
             "When a POST request is made to the issue processor AND the action is 'transition'".
                 f(() =>
-                    {
-                        Request.RequestUri = new Uri(_uriProcessor + "action=transition");
-                        Request.Method = HttpMethod.Post;
-                        Response = Client.SendAsync(Request).Result;
-                    });
+                {
+                    Request.RequestUri = new Uri(_uriProcessor + "action=transition");
+                    Request.Method = HttpMethod.Post;
+                    Response = Client.SendAsync(Request).Result;
+                });
             "Then a '404 Not Found' status is returned".
                 f(() => Response.StatusCode.ShouldEqual(HttpStatusCode.NotFound));
-            
         }
-        
     }
 }

--- a/test/WebApiBook.IssueTrackerApi.AcceptanceTests/Features/RetreivingHome.cs
+++ b/test/WebApiBook.IssueTrackerApi.AcceptanceTests/Features/RetreivingHome.cs
@@ -1,26 +1,20 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Net;
-using System.Net.Http;
-using System.Text;
-using System.Threading.Tasks;
 using Should;
 using Tavis.Home;
 using WebApiBook.IssueTrackerApi.Infrastructure;
-using WebApiBook.IssueTrackerApi.Models;
 using Xbehave;
 
 namespace WebApiBook.IssueTrackerApp.AcceptanceTests.Features
 {
     public class RetreivingHome : HomeFeature
     {
-        private Uri _uriHome = new Uri("http://localhost/");
+        private readonly Uri _uriHome = new Uri("http://localhost/");
 
         [Scenario]
         public void RetrievingHomeRepresentation(HomeDocument home)
         {
-            
             "When it is retrieved".
                f(() =>
                {
@@ -31,17 +25,16 @@ namespace WebApiBook.IssueTrackerApp.AcceptanceTests.Features
                });
             "Then a '200 OK' status is returned".
                 f(() => Response.StatusCode.ShouldEqual(HttpStatusCode.OK));
-            "Then it is returned".
+            "And it is returned".
                 f(() => home.ShouldNotBeNull());
-            "Then it should have an issueprocessor link".
+            "And it should have an issueprocessor link".
                 f(() => home.Resources.FirstOrDefault(l => l.Relation == IssueLinkFactory.Rels.IssueProcessor).ShouldNotBeNull());
-            "Then it should have an issue link".
+            "And it should have an issue link".
                 f(() => home.Resources.FirstOrDefault(l => l.Relation == IssueLinkFactory.Rels.Issue).ShouldNotBeNull());
-            "Then it should have an issues link".
+            "And it should have an issues link".
                 f(() => home.Resources.FirstOrDefault(l => l.Relation == IssueLinkFactory.Rels.Issues).ShouldNotBeNull());
-            "Then it should have an search link".
+            "And it should have an search link".
                 f(() => home.Resources.FirstOrDefault(l => l.Relation == IssueLinkFactory.Rels.SearchQuery).ShouldNotBeNull());
-
         }
     }
 }

--- a/test/WebApiBook.IssueTrackerApi.AcceptanceTests/Features/RetrievingIssues.cs
+++ b/test/WebApiBook.IssueTrackerApi.AcceptanceTests/Features/RetrievingIssues.cs
@@ -1,11 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
-using Moq;
 using Should;
 using WebApiBook.IssueTrackerApi.Infrastructure;
 using WebApiBook.IssueTrackerApi.Models;
@@ -17,52 +15,52 @@ namespace WebApiBook.IssueTrackerApp.AcceptanceTests.Features
 {
     public class RetrievingIssues : IssuesFeature
     {
-        private Uri _uriIssues = new Uri("http://localhost/issue");
-        private Uri _uriIssue1 = new Uri("http://localhost/issue/1");
-        private Uri _uriIssue2 = new Uri("http://localhost/issue/2");
- 
+        private readonly Uri _uriIssues = new Uri("http://localhost/issue");
+        private readonly Uri _uriIssue1 = new Uri("http://localhost/issue/1");
+        private readonly Uri _uriIssue2 = new Uri("http://localhost/issue/2");
+
         [Scenario]
         public void RetrievingAnIssue(IssueState issue, Issue fakeIssue)
         {
             "Given an existing issue".
                 f(() =>
-                    {
-                        fakeIssue = FakeIssues.FirstOrDefault();
-                        MockIssueStore.Setup(i => i.FindAsync("1")).Returns(Task.FromResult(fakeIssue));
-                    });
+                {
+                    fakeIssue = FakeIssues.FirstOrDefault();
+                    MockIssueStore.Setup(i => i.FindAsync("1")).Returns(Task.FromResult(fakeIssue));
+                });
             "When it is retrieved".
                 f(() =>
-                    {
-                        Request.RequestUri = _uriIssue1;
-                        Response = Client.SendAsync(Request).Result;
-                        issue = Response.Content.ReadAsAsync<IssueState>().Result;
-                    });
+                {
+                    Request.RequestUri = _uriIssue1;
+                    Response = Client.SendAsync(Request).Result;
+                    issue = Response.Content.ReadAsAsync<IssueState>().Result;
+                });
             "Then a '200 OK' status is returned".
                 f(() => Response.StatusCode.ShouldEqual(HttpStatusCode.OK));
-            "Then it is returned".
+            "And it is returned".
                 f(() => issue.ShouldNotBeNull());
-            "Then it should have an id".
+            "And it should have an id".
                 f(() => issue.Id.ShouldEqual(fakeIssue.Id));
-            "Then it should have a title".
+            "And it should have a title".
                 f(() => issue.Title.ShouldEqual(fakeIssue.Title));
-            "Then it should have a description".
+            "And it should have a description".
                 f(() => issue.Description.ShouldEqual(fakeIssue.Description));
-            "Then it should have a state".
+            "And it should have a state".
                 f(() => issue.Status.ShouldEqual(Enum.GetName(typeof(IssueStatus), fakeIssue.Status)));
-            "Then it should have a 'self' link".
+            "And it should have a 'self' link".
                 f(() =>
-                    {
-                        var link = issue.Links.FirstOrDefault(l => l.Rel == IssueLinkFactory.Rels.Self);
-                        link.ShouldNotBeNull();
-                        link.Href.AbsoluteUri.ShouldEqual("http://localhost/issue/1");
-                    });
-            "Then it should have a transition link".
+                {
+                    var link = issue.Links.FirstOrDefault(l => l.Rel == IssueLinkFactory.Rels.Self);
+                    link.ShouldNotBeNull();
+                    link.Href.AbsoluteUri.ShouldEqual("http://localhost/issue/1");
+                });
+            "And it should have a transition link".
                 f(() =>
-                    {
-                        var link = issue.Links.FirstOrDefault(l => l.Rel == IssueLinkFactory.Rels.Transition && l.Action == IssueLinkFactory.Actions.Transition);
-                        link.ShouldNotBeNull();
-                        link.Href.AbsoluteUri.ShouldEqual("http://localhost/issueprocessor/1?action=transition");
-                    });
+                {
+                    var link = issue.Links.FirstOrDefault(l => l.Rel == IssueLinkFactory.Rels.Transition && l.Action == IssueLinkFactory.Actions.Transition);
+                    link.ShouldNotBeNull();
+                    link.Href.AbsoluteUri.ShouldEqual("http://localhost/issueprocessor/1?action=transition");
+                });
         }
 
         [Scenario]
@@ -70,23 +68,23 @@ namespace WebApiBook.IssueTrackerApp.AcceptanceTests.Features
         {
             "Given an existing open issue".
                 f(() =>
-                    {
-                        fakeIssue = FakeIssues.Single(i => i.Status == IssueStatus.Open);
-                        MockIssueStore.Setup(i => i.FindAsync("1")).Returns(Task.FromResult(fakeIssue));
-                    });
+                {
+                    fakeIssue = FakeIssues.Single(i => i.Status == IssueStatus.Open);
+                    MockIssueStore.Setup(i => i.FindAsync("1")).Returns(Task.FromResult(fakeIssue));
+                });
             "When it is retrieved".
                 f(() =>
-                    {
-                        Request.RequestUri = _uriIssue1;
-                        issue = Client.SendAsync(Request).Result.Content.ReadAsAsync<IssueState>().Result;
-                    });
+                {
+                    Request.RequestUri = _uriIssue1;
+                    issue = Client.SendAsync(Request).Result.Content.ReadAsAsync<IssueState>().Result;
+                });
             "Then it should have a 'close' action link".
                 f(() =>
-                    {
-                        var link = issue.Links.FirstOrDefault(l => l.Rel == IssueLinkFactory.Rels.Close && l.Action == IssueLinkFactory.Actions.Close);
-                        link.ShouldNotBeNull();
-                        link.Href.AbsoluteUri.ShouldEqual("http://localhost/issueprocessor/1?action=close");
-                    });
+                {
+                    var link = issue.Links.FirstOrDefault(l => l.Rel == IssueLinkFactory.Rels.Close && l.Action == IssueLinkFactory.Actions.Close);
+                    link.ShouldNotBeNull();
+                    link.Href.AbsoluteUri.ShouldEqual("http://localhost/issueprocessor/1?action=close");
+                });
         }
 
         [Scenario]
@@ -94,24 +92,23 @@ namespace WebApiBook.IssueTrackerApp.AcceptanceTests.Features
         {
             "Given an existing closed issue".
                 f(() =>
-                    {
-                        fakeIssue = FakeIssues.Single(i => i.Status == IssueStatus.Closed);
-                        MockIssueStore.Setup(i => i.FindAsync("2")).Returns(Task.FromResult(fakeIssue));
-                    });
+                {
+                    fakeIssue = FakeIssues.Single(i => i.Status == IssueStatus.Closed);
+                    MockIssueStore.Setup(i => i.FindAsync("2")).Returns(Task.FromResult(fakeIssue));
+                });
             "When it is retrieved".
                 f(() =>
-                    {
-                        Request.RequestUri = _uriIssue2;
-                        issue = Client.SendAsync(Request).Result.Content.ReadAsAsync<IssueState>().Result;
-                    });
+                {
+                    Request.RequestUri = _uriIssue2;
+                    issue = Client.SendAsync(Request).Result.Content.ReadAsAsync<IssueState>().Result;
+                });
             "Then it should have a 'open' action link".
                 f(() =>
-                    {
-                        var link = issue.Links.FirstOrDefault(l => l.Rel == IssueLinkFactory.Rels.Open && l.Action == IssueLinkFactory.Actions.Open);
-                        link.ShouldNotBeNull();
-                        link.Href.AbsoluteUri.ShouldEqual("http://localhost/issueprocessor/2?action=open");
-
-                    });
+                {
+                    var link = issue.Links.FirstOrDefault(l => l.Rel == IssueLinkFactory.Rels.Open && l.Action == IssueLinkFactory.Actions.Open);
+                    link.ShouldNotBeNull();
+                    link.Href.AbsoluteUri.ShouldEqual("http://localhost/issueprocessor/2?action=open");
+                });
         }
 
         [Scenario]
@@ -121,10 +118,10 @@ namespace WebApiBook.IssueTrackerApp.AcceptanceTests.Features
                 f(() => MockIssueStore.Setup(i => i.FindAsync("1")).Returns(Task.FromResult((Issue)null)));
             "When it is retrieved".
                 f(() =>
-                    {
-                        Request.RequestUri = _uriIssue1;
-                        Response = Client.SendAsync(Request).Result;
-                    });
+                {
+                    Request.RequestUri = _uriIssue1;
+                    Response = Client.SendAsync(Request).Result;
+                });
             "Then a '404 Not Found' status is returned".
                 f(() => Response.StatusCode.ShouldEqual(HttpStatusCode.NotFound));
         }
@@ -136,26 +133,26 @@ namespace WebApiBook.IssueTrackerApp.AcceptanceTests.Features
                 f(() => MockIssueStore.Setup(i => i.FindAsync()).Returns(Task.FromResult(FakeIssues)));
             "When all issues are retrieved".
                 f(() =>
-                    {
-                        Request.RequestUri = _uriIssues;
-                        Response = Client.SendAsync(Request).Result;
-                        issuesState = Response.Content.ReadAsAsync<IssuesState>().Result;
-                    });
+                {
+                    Request.RequestUri = _uriIssues;
+                    Response = Client.SendAsync(Request).Result;
+                    issuesState = Response.Content.ReadAsAsync<IssuesState>().Result;
+                });
             "Then a '200 OK' status is returned".
                 f(() => Response.StatusCode.ShouldEqual(HttpStatusCode.OK));
-            "Then they are returned".
+            "And they are returned".
                 f(() =>
-                    {
-                        issuesState.Issues.FirstOrDefault(i => i.Id == "1").ShouldNotBeNull();
-                        issuesState.Issues.FirstOrDefault(i => i.Id == "2").ShouldNotBeNull();
-                    });
-            "Then the collection should have a 'self' link".
+                {
+                    issuesState.Issues.FirstOrDefault(i => i.Id == "1").ShouldNotBeNull();
+                    issuesState.Issues.FirstOrDefault(i => i.Id == "2").ShouldNotBeNull();
+                });
+            "And the collection should have a 'self' link".
                 f(() =>
-                    {
-                        var link = issuesState.Links.FirstOrDefault(l => l.Rel == IssueLinkFactory.Rels.Self);
-                        link.ShouldNotBeNull();
-                        link.Href.AbsoluteUri.ShouldEqual("http://localhost/issue");
-                    });
+                {
+                    var link = issuesState.Links.FirstOrDefault(l => l.Rel == IssueLinkFactory.Rels.Self);
+                    link.ShouldNotBeNull();
+                    link.Href.AbsoluteUri.ShouldEqual("http://localhost/issue");
+                });
         }
 
         [Scenario]
@@ -165,27 +162,26 @@ namespace WebApiBook.IssueTrackerApp.AcceptanceTests.Features
                 f(() => MockIssueStore.Setup(i => i.FindAsync()).Returns(Task.FromResult(FakeIssues)));
             "When all issues are retrieved as Collection+Json".
                 f(() =>
-                    {
-                        Request.RequestUri = _uriIssues;
-                        Request.Headers.Accept.Clear();
-                        Request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.collection+json"));
-                        Response = Client.SendAsync(Request).Result;
-                        readDocument = Response.Content.ReadAsAsync<ReadDocument>(new[] {new CollectionJsonFormatter()}).Result;
-                    });
+                {
+                    Request.RequestUri = _uriIssues;
+                    Request.Headers.Accept.Clear();
+                    Request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.collection+json"));
+                    Response = Client.SendAsync(Request).Result;
+                    readDocument = Response.Content.ReadAsAsync<ReadDocument>(new[] { new CollectionJsonFormatter() }).Result;
+                });
             "Then a '200 OK' status is returned".
                f(() => Response.StatusCode.ShouldEqual(HttpStatusCode.OK));
-            "Then Collection+Json is returned".
+            "And Collection+Json is returned".
                 f(() => readDocument.ShouldNotBeNull());
-            "Then the href should be set".
+            "And the href should be set".
                 f(() => readDocument.Collection.Href.AbsoluteUri.ShouldEqual("http://localhost/issue"));
-            "Then all issues are returned".
+            "And all issues are returned".
                 f(() =>
-                    {
-                        readDocument.Collection.Items.FirstOrDefault(i=>i.Href.AbsoluteUri=="http://localhost/issue/1").ShouldNotBeNull();
-                        readDocument.Collection.Items.FirstOrDefault(i=>i.Href.AbsoluteUri=="http://localhost/issue/2").ShouldNotBeNull();
-                    });
-                
-            "Then the search query is returned".
+                {
+                    readDocument.Collection.Items.FirstOrDefault(i => i.Href.AbsoluteUri == "http://localhost/issue/1").ShouldNotBeNull();
+                    readDocument.Collection.Items.FirstOrDefault(i => i.Href.AbsoluteUri == "http://localhost/issue/2").ShouldNotBeNull();
+                });
+            "And the search query is returned".
                 f(() => readDocument.Collection.Queries.SingleOrDefault(
                             q => q.Rel == IssueLinkFactory.Rels.SearchQuery).ShouldNotBeNull());
         }
@@ -194,7 +190,7 @@ namespace WebApiBook.IssueTrackerApp.AcceptanceTests.Features
         public void SearchingIssues(IssuesState issuesState)
         {
             "Given existing issues".
-                f(() => MockIssueStore.Setup(i => i.FindAsyncQuery("another")).Returns(Task.FromResult(FakeIssues.Where(i=>i.Id == "2"))));
+                f(() => MockIssueStore.Setup(i => i.FindAsyncQuery("another")).Returns(Task.FromResult(FakeIssues.Where(i => i.Id == "2"))));
             "When issues are searched".
                 f(() =>
                 {
@@ -204,19 +200,19 @@ namespace WebApiBook.IssueTrackerApp.AcceptanceTests.Features
                 });
             "Then a '200 OK' status is returned".
                 f(() => Response.StatusCode.ShouldEqual(HttpStatusCode.OK));
-            "Then the collection should have a 'self' link".
+            "And the collection should have a 'self' link".
                 f(() =>
                 {
                     var link = issuesState.Links.FirstOrDefault(l => l.Rel == IssueLinkFactory.Rels.Self);
                     link.ShouldNotBeNull();
                     link.Href.AbsoluteUri.ShouldEqual("http://localhost/issue?searchtext=another");
                 });
-            "Then the matching issues are returned".
+            "And the matching issues are returned".
                 f(() =>
-                    {
-                        var issue = issuesState.Issues.FirstOrDefault();
-                        issue.ShouldNotBeNull();
-                        issue.Id.ShouldEqual("2");
+                {
+                    var issue = issuesState.Issues.FirstOrDefault();
+                    issue.ShouldNotBeNull();
+                    issue.Id.ShouldEqual("2");
                 });
         }
     }

--- a/test/WebApiBook.IssueTrackerApi.AcceptanceTests/Features/UpdatingIssues.cs
+++ b/test/WebApiBook.IssueTrackerApi.AcceptanceTests/Features/UpdatingIssues.cs
@@ -14,36 +14,36 @@ namespace WebApiBook.IssueTrackerApp.AcceptanceTests.Features
 {
     public class UpdatingIssues : IssuesFeature
     {
-        private Uri _uriIssue1 = new Uri("http://localhost/issue/1");
+        private readonly Uri _uriIssue1 = new Uri("http://localhost/issue/1");
 
         [Scenario]
         public void UpdatingAnIssue(Issue fakeIssue, string title)
         {
             "Given an existing issue".
                 f(() =>
-                    {
-                        fakeIssue = FakeIssues.FirstOrDefault();
-                        title = fakeIssue.Title;
-                        MockIssueStore.Setup(i => i.FindAsync("1")).Returns(Task.FromResult(fakeIssue));
-                        MockIssueStore.Setup(i => i.UpdateAsync(It.IsAny<Issue>())).Returns(Task.FromResult(""));
-                    });
+                {
+                    fakeIssue = FakeIssues.FirstOrDefault();
+                    title = fakeIssue.Title;
+                    MockIssueStore.Setup(i => i.FindAsync("1")).Returns(Task.FromResult(fakeIssue));
+                    MockIssueStore.Setup(i => i.UpdateAsync(It.IsAny<Issue>())).Returns(Task.FromResult(""));
+                });
             "When a PATCH request is made".
                 f(() =>
-                    {
-                        dynamic issue = new JObject();
-                        issue.description = "Updated description";  
-                        Request.Method = new HttpMethod("PATCH");
-                        Request.RequestUri = _uriIssue1;
-                        Request.Content = new ObjectContent<dynamic>(issue, new JsonMediaTypeFormatter());
-                        Response = Client.SendAsync(Request).Result;
-                    });
+                {
+                    dynamic issue = new JObject();
+                    issue.description = "Updated description";
+                    Request.Method = new HttpMethod("PATCH");
+                    Request.RequestUri = _uriIssue1;
+                    Request.Content = new ObjectContent<dynamic>(issue, new JsonMediaTypeFormatter());
+                    Response = Client.SendAsync(Request).Result;
+                });
             "Then a '200 OK' status is returned".
                 f(() => Response.StatusCode.ShouldEqual(HttpStatusCode.OK));
-            "Then the issue should be updated".
+            "And the issue should be updated".
                 f(() => MockIssueStore.Verify(i => i.UpdateAsync(It.IsAny<Issue>())));
-            "Then the descripton should be updated".
+            "And the descripton should be updated".
                 f(() => fakeIssue.Description.ShouldEqual("Updated description"));
-            "Then the title should not change".
+            "And the title should not change".
                 f(() => fakeIssue.Title.ShouldEqual(title));
         }
 
@@ -54,15 +54,14 @@ namespace WebApiBook.IssueTrackerApp.AcceptanceTests.Features
                 f(() => MockIssueStore.Setup(i => i.FindAsync("1")).Returns(Task.FromResult((Issue)null)));
             "When a PATCH request is made".
                 f(() =>
-                    {
-                        Request.Method = new HttpMethod("PATCH");
-                        Request.RequestUri = _uriIssue1;
-                        Request.Content = new ObjectContent<dynamic>(new JObject(), new JsonMediaTypeFormatter());
-                        Response = Client.SendAsync(Request).Result;
-                    });
+                {
+                    Request.Method = new HttpMethod("PATCH");
+                    Request.RequestUri = _uriIssue1;
+                    Request.Content = new ObjectContent<dynamic>(new JObject(), new JsonMediaTypeFormatter());
+                    Response = Client.SendAsync(Request).Result;
+                });
             "Then a 404 Not Found status is returned".
                 f(() => Response.StatusCode.ShouldEqual(HttpStatusCode.NotFound));
         }
-
     }
 }

--- a/test/WebApiBook.IssueTrackerApi.AcceptanceTests/HomeFeature.cs
+++ b/test/WebApiBook.IssueTrackerApi.AcceptanceTests/HomeFeature.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net.Http;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Net.Http;
 using System.Web.Http;
 
 namespace WebApiBook.IssueTrackerApp.AcceptanceTests
@@ -14,7 +9,7 @@ namespace WebApiBook.IssueTrackerApp.AcceptanceTests
         public HttpRequestMessage Request;
         public HttpResponseMessage Response;
 
-        public HomeFeature()
+        protected HomeFeature()
         {
             Request = new HttpRequestMessage();
 
@@ -23,7 +18,5 @@ namespace WebApiBook.IssueTrackerApp.AcceptanceTests
             var server = new HttpServer(config);
             Client = new HttpClient(server);
         }
-
-
     }
 }

--- a/test/WebApiBook.IssueTrackerApi.AcceptanceTests/IssuesFeature.cs
+++ b/test/WebApiBook.IssueTrackerApi.AcceptanceTests/IssuesFeature.cs
@@ -3,7 +3,6 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Web.Http;
 using Moq;
-using WebApiBook.IssueTrackerApi.Controllers;
 using WebApiBook.IssueTrackerApi.Infrastructure;
 using WebApiBook.IssueTrackerApi.Models;
 
@@ -19,7 +18,7 @@ namespace WebApiBook.IssueTrackerApp.AcceptanceTests
         public HttpRequestMessage Request { get; private set; }
         public HttpClient Client;
 
-        public IssuesFeature()
+        protected IssuesFeature()
         {
             MockIssueStore = new Mock<IIssueStore>();
             Request = new HttpRequestMessage();
@@ -35,10 +34,23 @@ namespace WebApiBook.IssueTrackerApp.AcceptanceTests
 
         private IEnumerable<Issue> GetFakeIssues()
         {
-            var fakeIssues = new List<Issue>();
-            fakeIssues.Add(new Issue { Id = "1", Title = "An issue", Description = "This is an issue", Status = IssueStatus.Open });
-            fakeIssues.Add(new Issue { Id = "2", Title = "Another issue", Description = "This is another issue", Status = IssueStatus.Closed });
-            return fakeIssues;
+            return new List<Issue>
+            {
+                new Issue
+                {
+                    Id = "1",
+                    Title = "An issue",
+                    Description = "This is an issue", 
+                    Status = IssueStatus.Open,
+                },
+                new Issue
+                {
+                    Id = "2",
+                    Title = "Another issue",
+                    Description = "This is another issue",
+                    Status = IssueStatus.Closed,
+                },
+            };
         }
     }
 }


### PR DESCRIPTION
- aligned tabulation of step bodies
- added readonly to fields
- converted step to "And..." where appropriate
- removed redundant usings
- removed redundant blank lines
- made abstract type constructors protected
- converted list creation to initializer
